### PR TITLE
Update 08_lesson.rst

### DIFF
--- a/tutorial/08_lesson.rst
+++ b/tutorial/08_lesson.rst
@@ -268,7 +268,8 @@ outputs of the CLI and Build Tool.
 
 In the ``check_availability`` operation, let's create a temporary password if
 an email address is available. We'll just add a few lines to our script to
-randomly generate a short password if the address is available. In the
+randomly generate a short password if the address is available. We'll use a
+``string`` function for this, so we'll need to add ``import string`` to our script. In the
 ``outputs`` section, we'll mark that password as ``sensitive``. Notice,
 that when we add a ``sensitive`` property to an output we have to add a
 ``value`` property as well.
@@ -278,6 +279,7 @@ that when we add a ``sensitive`` property to an output we have to add a
     python_action:
       script: |
         import random
+        import string
         rand = random.randint(0, 2)
         vacant = rand != 0
         # print vacant


### PR DESCRIPTION
The tutorial code block is missing the line `import string` which results in an error when you attempt to run this tutorial:

```
Command failed java.lang.RuntimeException: Slang Error: Error executing python script: Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "<string>", line 6, in <genexpr>
NameError: global name 'string' is not defined
```

This line does appear in the actual code shown at the end of the page.
